### PR TITLE
feat: added DefineBinder function to AvoidAOTErrors

### DIFF
--- a/Packages/RosettaUI/Runtime/IL2CPP/AvoidAOTError.cs
+++ b/Packages/RosettaUI/Runtime/IL2CPP/AvoidAOTError.cs
@@ -43,6 +43,10 @@ namespace RosettaUI.IL2CPP
             DefineTypes_PropertyOrFieldBinder<T>();
         }
 
+        public static void DefineBinder<TParent, TValue>()
+        {
+            new PropertyOrFieldBinder<TParent, TValue>(null, null);
+        }
 
         //　組み合わせ爆発するのでなんとかしたい
         static void DefineTypes_PropertyOrFieldBinder<T>()


### PR DESCRIPTION
This allows to define binders for custom type-member pairs to avoid AOT errors