### PR TITLE
Support Some Attribute

### DIFF
--- a/Assets/Example/Runtime/Categories/FieldExample.cs
+++ b/Assets/Example/Runtime/Categories/FieldExample.cs
@@ -17,7 +17,7 @@ namespace RosettaUI.Example
             [Range(0f,100f)]
             public float rangeFloat;
 
-            [Space(12f)]
+            [Space(24f)]
             public uint spaceUint;
 
             [Multiline]
@@ -25,6 +25,9 @@ namespace RosettaUI.Example
 
             [NonReorderable]
             public List<int> nonReorderableList;
+            
+            [HideInInspector]
+            public Vector2 hideInInspectorVector2;
         }
 
         public int intValue;
@@ -127,14 +130,23 @@ namespace RosettaUI.Example
                     ExampleTemplate.CodeElementSets("Attribute",
                         (@"public class AttributeExampleClass
 {
+    [Header(""Header"")]
+    public int headerInt;
+
     [Range(0f,100f)]
     public float rangeFloat;
+
+    [Space(24f)]
+    public uint spaceUint;
 
     [Multiline]
     public string multiLineString;
 
     [NonReorderable]
     public List<int> nonReorderableList;
+        
+    [HideInInspector]
+    public Vector2 hideInInspectorVector2;
 }
 
 UI.Field(() => attributeExampleClass).Open();

--- a/Assets/Example/Runtime/Categories/FieldExample.cs
+++ b/Assets/Example/Runtime/Categories/FieldExample.cs
@@ -11,8 +11,14 @@ namespace RosettaUI.Example
         [Serializable]
         public class AttributeExampleClass
         {
+            [Header("Header")]
+            public int headerInt;
+
             [Range(0f,100f)]
             public float rangeFloat;
+
+            [Space(12f)]
+            public uint spaceUint;
 
             [Multiline]
             public string multiLineString;

--- a/Assets/Example/Utility/SyntaxHighligher.cs
+++ b/Assets/Example/Utility/SyntaxHighligher.cs
@@ -18,9 +18,12 @@ namespace RosettaUI.Example
                 "T",
                 nameof(Enumerable),
                 
+                "(?<!\\.)Header",
+                "(?<!\\.)Space",
                 "Multiline",
                 "NonReorderable",
                 "NonSerialized",
+                "HideInInspector",
                 nameof(Vector2),
                 nameof(Color),
                 nameof(Screen),

--- a/Packages/RosettaUI/Runtime/UI/BinderToElement/BinderToElement_Field.cs
+++ b/Packages/RosettaUI/Runtime/UI/BinderToElement/BinderToElement_Field.cs
@@ -137,7 +137,7 @@ namespace RosettaUI
                 
                 // 属性によるElementの付加, Propertyの変更
                 List<Element> innerElements = new();
-                foreach (var attr in TypeUtility.GetPropertyAttributes(valueType, fieldName).OrderBy(a => a.order))
+                foreach (var attr in TypeUtility.GetPropertyAttributes(valueType, fieldName))
                 {
                     switch (attr)
                     {

--- a/Packages/RosettaUI/Runtime/UI/BinderToElement/BinderToElement_Field.cs
+++ b/Packages/RosettaUI/Runtime/UI/BinderToElement/BinderToElement_Field.cs
@@ -116,8 +116,6 @@ namespace RosettaUI
 
             var elements = TypeUtility.GetUITargetFieldNames(valueType).Select(fieldName =>
             {
-                if (TypeUtility.IsHideInInspector(valueType, fieldName)) return null;
-                
                 var fieldBinder = PropertyOrFieldBinder.Create(binder, fieldName);
                 var fieldLabel = UICustom.ModifyPropertyOrFieldLabel(valueType, fieldName);
 

--- a/Packages/RosettaUI/Runtime/UI/BinderToElement/BinderToElement_Field.cs
+++ b/Packages/RosettaUI/Runtime/UI/BinderToElement/BinderToElement_Field.cs
@@ -116,20 +116,52 @@ namespace RosettaUI
 
             var elements = TypeUtility.GetUITargetFieldNames(valueType).Select(fieldName =>
             {
+                if (TypeUtility.IsHideInInspector(valueType, fieldName)) return null;
+                
                 var fieldBinder = PropertyOrFieldBinder.Create(binder, fieldName);
                 var fieldLabel = UICustom.ModifyPropertyOrFieldLabel(valueType, fieldName);
-                Element targetElement = null;
 
-                var range = TypeUtility.GetRange(valueType, fieldName);
-                if (range != null)
+                Element targetElement;
+
+                // 属性によるElementの変更
+                var rangeAttr = TypeUtility.GetRange(valueType, fieldName);
+                if (rangeAttr is not null)
                 {
-                    var (minGetter, maxGetter) = RangeUtility.CreateGetterMinMax(range, fieldBinder.ValueType);
-                    targetElement ??= UI.Slider(fieldLabel, fieldBinder, minGetter, maxGetter);
+                    var (minGetter, maxGetter) = RangeUtility.CreateGetterMinMax(rangeAttr, fieldBinder.ValueType);
+                    targetElement = UI.Slider(fieldLabel, fieldBinder, minGetter, maxGetter);
                 }
-               
-                targetElement ??= UI.Field(fieldLabel, fieldBinder, optionCaptured);
+                else
+                {
+                    targetElement = UI.Field(fieldLabel, fieldBinder, optionCaptured);
+                }
+                
+                // 属性によるElementの付加, Propertyの変更
+                List<Element> innerElements = new();
+                foreach (var attr in TypeUtility.GetPropertyAttributes(valueType, fieldName).OrderBy(a => a.order))
+                {
+                    switch (attr)
+                    {
+                        case HeaderAttribute headerAttr:
+                            innerElements.Add(UI.Space().SetHeight(18f));
+                            innerElements.Add(UI.Label($"<b>{headerAttr.header}</b>"));
+                            break;
+                        case SpaceAttribute spaceAttr:
+                            innerElements.Add(UI.Space().SetHeight(spaceAttr.height));
+                            break;
+                        case MultilineAttribute _ when targetElement is TextFieldElement textField:
+                            textField.IsMultiLine = true;
+                            break;
+                    }
+                }
+                
+                if (innerElements.Count == 0)
+                {
+                    return targetElement;
+                }
+                
+                innerElements.Add(targetElement);
 
-                return GetModifiedElementByAttributes(targetElement, valueType, fieldName);
+                return UI.Column(innerElements);
             });
 
 
@@ -151,38 +183,6 @@ namespace RosettaUI
                 {
                     new HelpBoxElement($"[{type}] Circular reference detected.", HelpBoxType.Error)
                 }).SetInteractable(false);
-        }
-
-        private static Element GetModifiedElementByAttributes(Element el, Type valueType, string fieldName)
-        {
-            Element target = el;
-            List<Element> innerElements = new();
-
-            var space = TypeUtility.GetSpace(valueType,fieldName);
-            if (space is not null)
-            {
-                innerElements.Add(UI.Space().SetHeight(space.height));
-            }
-
-            var header = TypeUtility.GetHeader(valueType, fieldName);
-            if (header is not null)
-            {
-                innerElements.Add(UI.Space().SetHeight(12f));
-                innerElements.Add(UI.Label($"<b>{header.header}</b>"));
-            }
-
-            if (TypeUtility.IsMultiline(valueType, fieldName) && target is TextFieldElement textField)
-            {
-                textField.IsMultiLine = true;
-            }
-
-            if (innerElements.Count == 0)
-            {
-                return target;
-            }
-
-            innerElements.Add(target);
-            return UI.Column(innerElements);
         }
     }
 }

--- a/Packages/RosettaUI/Runtime/Utilities/TypeUtility.cs
+++ b/Packages/RosettaUI/Runtime/Utilities/TypeUtility.cs
@@ -71,6 +71,16 @@ namespace RosettaUI
             return GetMemberData(type, propertyOrFieldName).range;
         }
 
+        public static HeaderAttribute GetHeader(Type type, string propertyOrFieldName)
+        {
+            return GetMemberData(type, propertyOrFieldName).header;
+        }
+
+        public static SpaceAttribute GetSpace(Type type, string propertyOrFieldName)
+        {
+            return GetMemberData(type, propertyOrFieldName).space;
+        }
+
         public static bool IsReorderable(Type type, string propertyOrFieldName)
         {
             return GetMemberData(type, propertyOrFieldName).isReorderable;
@@ -205,6 +215,8 @@ namespace RosettaUI
                             type = pair.Item2,
                             memberInfo = pair.Item1,
                             range = pair.Item1.GetCustomAttribute<RangeAttribute>(),
+                            header = pair.Item1.GetCustomAttribute<HeaderAttribute>(),
+                            space = pair.Item1.GetCustomAttribute<SpaceAttribute>(),
                             isReorderable = pair.Item1.GetCustomAttribute<NonReorderableAttribute>() == null,
                             isMultiline =  pair.Item1.GetCustomAttribute<MultilineAttribute>() != null
                         }
@@ -225,6 +237,8 @@ namespace RosettaUI
                 public Type type;
                 public MemberInfo memberInfo;
                 public RangeAttribute range;
+                public HeaderAttribute header;
+                public SpaceAttribute space;
                 public bool isReorderable;
                 public bool isMultiline;
             }

--- a/Packages/RosettaUI/Runtime/Utilities/TypeUtility.cs
+++ b/Packages/RosettaUI/Runtime/Utilities/TypeUtility.cs
@@ -75,11 +75,6 @@ namespace RosettaUI
         {
             return GetMemberData(type, propertyOrFieldName).range;
         }
-        
-        public static bool IsHideInInspector(Type type, string propertyOrFieldName)
-        {
-            return GetMemberData(type, propertyOrFieldName).isHideInInspector;
-        }
 
         public static bool IsReorderable(Type type, string propertyOrFieldName)
         {
@@ -211,7 +206,6 @@ namespace RosettaUI
                             memberInfo = pair.Item1,
                             propertyAttributes = pair.Item1.GetCustomAttributes<PropertyAttribute>().OrderBy(attr => attr.order).ToArray(),
                             range = pair.Item1.GetCustomAttribute<RangeAttribute>(),
-                            isHideInInspector = pair.Item1.GetCustomAttribute<HideInInspector>() != null,
                             isReorderable = pair.Item1.GetCustomAttribute<NonReorderableAttribute>() == null,
                         }
                     );
@@ -220,8 +214,9 @@ namespace RosettaUI
                 uiTargetPropertyOrFieldsNameTypeDic = fis
                     .Where(fi => !fi.IsInitOnly)
                     .Where(fi =>
-                        (fi.IsPublic && fi.GetCustomAttribute<NonSerializedAttribute>() == null)
-                        || fi.GetCustomAttribute<SerializeField>() != null
+                        ((fi.IsPublic && fi.GetCustomAttribute<NonSerializedAttribute>() == null)
+                        || fi.GetCustomAttribute<SerializeField>() != null)
+                        && fi.GetCustomAttribute<HideInInspector>() == null
                     )
                     .ToDictionary(fi => fi.Name, fi => fi.FieldType);
             }
@@ -232,7 +227,6 @@ namespace RosettaUI
                 public MemberInfo memberInfo;
                 public RangeAttribute range;
                 public IEnumerable<PropertyAttribute> propertyAttributes;
-                public bool isHideInInspector;
                 public bool isReorderable;
             }
         }

--- a/Packages/RosettaUI/Runtime/Utilities/TypeUtility.cs
+++ b/Packages/RosettaUI/Runtime/Utilities/TypeUtility.cs
@@ -65,30 +65,25 @@ namespace RosettaUI
         {
             return GetMemberData(type, propertyOrFieldName)?.memberInfo;
         }
+        
+        public static IEnumerable<PropertyAttribute> GetPropertyAttributes(Type type, string propertyOrFieldName)
+        {
+            return GetMemberData(type, propertyOrFieldName).propertyAttributes;
+        }
 
         public static RangeAttribute GetRange(Type type, string propertyOrFieldName)
         {
             return GetMemberData(type, propertyOrFieldName).range;
         }
-
-        public static HeaderAttribute GetHeader(Type type, string propertyOrFieldName)
+        
+        public static bool IsHideInInspector(Type type, string propertyOrFieldName)
         {
-            return GetMemberData(type, propertyOrFieldName).header;
-        }
-
-        public static SpaceAttribute GetSpace(Type type, string propertyOrFieldName)
-        {
-            return GetMemberData(type, propertyOrFieldName).space;
+            return GetMemberData(type, propertyOrFieldName).isHideInInspector;
         }
 
         public static bool IsReorderable(Type type, string propertyOrFieldName)
         {
             return GetMemberData(type, propertyOrFieldName).isReorderable;
-        }
-
-        public static bool IsMultiline(Type type, string propertyOrFieldName)
-        {
-            return GetMemberData(type, propertyOrFieldName).isMultiline;
         }
         
 
@@ -214,11 +209,10 @@ namespace RosettaUI
                         {
                             type = pair.Item2,
                             memberInfo = pair.Item1,
+                            propertyAttributes = pair.Item1.GetCustomAttributes<PropertyAttribute>().ToArray(),
                             range = pair.Item1.GetCustomAttribute<RangeAttribute>(),
-                            header = pair.Item1.GetCustomAttribute<HeaderAttribute>(),
-                            space = pair.Item1.GetCustomAttribute<SpaceAttribute>(),
+                            isHideInInspector = pair.Item1.GetCustomAttribute<HideInInspector>() != null,
                             isReorderable = pair.Item1.GetCustomAttribute<NonReorderableAttribute>() == null,
-                            isMultiline =  pair.Item1.GetCustomAttribute<MultilineAttribute>() != null
                         }
                     );
 
@@ -237,10 +231,9 @@ namespace RosettaUI
                 public Type type;
                 public MemberInfo memberInfo;
                 public RangeAttribute range;
-                public HeaderAttribute header;
-                public SpaceAttribute space;
+                public IEnumerable<PropertyAttribute> propertyAttributes;
+                public bool isHideInInspector;
                 public bool isReorderable;
-                public bool isMultiline;
             }
         }
         

--- a/Packages/RosettaUI/Runtime/Utilities/TypeUtility.cs
+++ b/Packages/RosettaUI/Runtime/Utilities/TypeUtility.cs
@@ -209,7 +209,7 @@ namespace RosettaUI
                         {
                             type = pair.Item2,
                             memberInfo = pair.Item1,
-                            propertyAttributes = pair.Item1.GetCustomAttributes<PropertyAttribute>().ToArray(),
+                            propertyAttributes = pair.Item1.GetCustomAttributes<PropertyAttribute>().OrderBy(attr => attr.order).ToArray(),
                             range = pair.Item1.GetCustomAttribute<RangeAttribute>(),
                             isHideInInspector = pair.Item1.GetCustomAttribute<HideInInspector>() != null,
                             isReorderable = pair.Item1.GetCustomAttribute<NonReorderableAttribute>() == null,


### PR DESCRIPTION
<img width="442" alt="image" src="https://github.com/fuqunaga/RosettaUI/assets/23546865/63c289b0-5285-4269-9ad3-591084b929cd">

クラスのメンバーを描画するときに、`[Header("header")]`, `[Space]`, `[HideInInspector]` 属性を表示に反映するようにしました。

When drawing members of the class, the `[Header("header")]`, `[Space]`, and `[HideInInspector]` attributes are now reflected in the drawing.