### PR TITLE
Support registration of custom attributes and flex basis / wrap settings

### DIFF
--- a/Assets/Example/Runtime/Categories/CustomExample.cs
+++ b/Assets/Example/Runtime/Categories/CustomExample.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using UnityEngine;
 
 namespace RosettaUI.Example
@@ -24,21 +25,42 @@ namespace RosettaUI.Example
             public float PropertyValue { get; set; }
         }
 
+        public class MySuffixAttribute : PropertyAttribute
+        {
+            public string suffix;
+        }
+
+        public class MyDropDownAttribute : PropertyAttribute { }
+
+        [Serializable]
+        public class MyAttributeClass
+        {
+            public float value;
+            [MySuffix(suffix = "suffix")] public float suffixValue;
+            public string stringValue;
+            [MyDropDown] public string myDropDownStringValue = "A";
+        }
+
         public MyFloat myFloatValue;
         public int intValue;
         public MyClass myClass;
         public Vector2 vector2Value;
-
+        public MyAttributeClass myAttributeClass;
 
         public Element CreateElement(LabelElement _)
         {
             SyntaxHighlighter.AddPattern("type", nameof(MyFloat));
             SyntaxHighlighter.AddPattern("type", nameof(MyClass));
+            SyntaxHighlighter.AddPattern("type", nameof(MyAttributeClass));
+            SyntaxHighlighter.AddPattern("type", nameof(PropertyAttribute));
+            SyntaxHighlighter.AddPattern("type", nameof(MySuffixAttribute));
+            SyntaxHighlighter.AddPattern("type", nameof(MyDropDownAttribute));
 
             return UI.Tabs(
                     CreateTabIElementCreator(),
                     CreateTabCreationFunc(),
-                    CreateTabPropertyField()
+                    CreateTabPropertyField(),
+                    CreateTabOverrideByAttributeFunc()
                 );
         }
 
@@ -101,7 +123,7 @@ UI.Field(() => intValue);
                 "publicValueNonSerialized",
                 "PropertyValue"
             );
-      
+
             using var labelModifierScope = new UICustom.PropertyOrFieldLabelModifierScope<Vector2>(
                 ("x", "horizontal"),
                 ("y", "vertical")
@@ -146,6 +168,55 @@ UI.Field(() => vector2Value);
                         )
                     )
                 );
+        }
+
+        private (string, Element) CreateTabOverrideByAttributeFunc()
+        {
+            using var modifyScope = UICustom.ElementModifyAttributeScope.Create<MySuffixAttribute>((attribute, element) =>
+            {
+                return UI.Row(element, UI.Label(attribute.suffix), UI.Space().SetWidth(4f));
+            });
+
+            using var overrideScope = UICustom.ElementOverrideAttributeScope.Create<MyDropDownAttribute, string>((attribute, label, readValue, writeValue) =>
+            {
+                return UI.Dropdown(label, readValue, writeValue, new[] { "A", "B", "C" });
+            });
+
+            return ExampleTemplate.CodeElementSetsWithDescriptionTab("ElementOverrideAttribute",
+                "Default field UI can be overridden / modified by custom element.",
+                (@"public class MySuffixAttribute : PropertyAttribute
+{
+    public string suffix;
+}
+
+public class MyDropDownAttribute : PropertyAttribute { }
+
+[Serializable]
+public class MyAttributeClass
+{
+    public float value;
+    [MySuffix(suffix = ""suffix"")] public float suffixValue;
+    public string stringValue;
+    [MyDropDown] public string myDropDownStringValue = ""A"";
+}
+
+public MyAttributeClass myAttributeClass;
+
+using var modifyScope = UICustom.ElementModifyAttributeScope.Create<MySuffixAttribute>((attribute, element) =>
+{
+    return UI.Row(element, UI.Label(attribute.suffix), UI.Space().SetWidth(4f));
+});
+
+using var overrideScope = UICustom.ElementOverrideAttributeScope.Create<MyDropDownAttribute, string>((attribute, label, readValue, writeValue) =>
+{
+    return UI.Dropdown(label, readValue, writeValue, new[] { ""A"", ""B"", ""C"" });
+});
+
+UI.Field(() => myAttributeClass);
+",
+                    UI.Field(() => myAttributeClass).Open()
+                )
+            );
         }
     }
 }

--- a/Assets/Example/Runtime/Categories/MethodExample.cs
+++ b/Assets/Example/Runtime/Categories/MethodExample.cs
@@ -28,7 +28,7 @@ namespace RosettaUI.Example
                     UI.Field(() => intValue).SetInteractable(false)),
                 ("UI.Button(\"Width\").SetWidth(300f);", UI.Button("Width").SetWidth(300f)),
                 ("UI.Button(\"Height\").SetHeight(100f);", UI.Button("Height").SetHeight(100f)),
-                ("UI.Row(\n    UI.Button(\"Flex\").SetFlexBasis(100f).SetFlexGrow(2f),\n    UI.Button(\"Flex\").SetFlexBasis(50f).SetFlexGrow(1f),\n    UI.Button(\"Flex\").SetFlexBasis(50f).SetFlexGrow(1f)\n).SetFlexWrap(true);", UI.Row(UI.Button("Flex").SetFlexBasis(100f).SetFlexGrow(2f), UI.Button("Flex").SetFlexBasis(50f).SetFlexGrow(1f), UI.Button("Flex").SetFlexBasis(50f).SetFlexGrow(1f)).SetFlexWrap(true)),
+                ("UI.Row(\n    UI.Button(\"Flex\").SetFlexBasis(100f).SetFlexGrow(2f),\n    UI.Button(\"FlexFlex\").SetFlexBasis(50f).SetFlexGrow(1f),\n    UI.Button(\"Flex\").SetFlexBasis(50f).SetFlexGrow(1f)\n).SetFlexWrap(true);", UI.Row(UI.Button("Flex").SetFlexBasis(100f).SetFlexGrow(2f), UI.Button("FlexFlex").SetFlexBasis(50f).SetFlexGrow(1f), UI.Button("Flex").SetFlexBasis(50f).SetFlexGrow(1f)).SetFlexWrap(true)),
                 ("UI.Button(\"Color\").SetColor(Color.red);", UI.Button("Color").SetColor(Color.red)),
                 ("UI.Button(\"BackgroundColor\").SetBackgroundColor(Color.blue);",
                     UI.Button("BackgroundColor").SetBackgroundColor(Color.blue))

--- a/Assets/Example/Runtime/Categories/MethodExample.cs
+++ b/Assets/Example/Runtime/Categories/MethodExample.cs
@@ -28,6 +28,7 @@ namespace RosettaUI.Example
                     UI.Field(() => intValue).SetInteractable(false)),
                 ("UI.Button(\"Width\").SetWidth(300f);", UI.Button("Width").SetWidth(300f)),
                 ("UI.Button(\"Height\").SetHeight(100f);", UI.Button("Height").SetHeight(100f)),
+                ("UI.Row(\n    UI.Button(\"Flex\").SetFlexBasis(100f).SetFlexGrow(2f),\n    UI.Button(\"Flex\").SetFlexBasis(50f).SetFlexGrow(1f),\n    UI.Button(\"Flex\").SetFlexBasis(50f).SetFlexGrow(1f)\n).SetFlexWrap(true);", UI.Row(UI.Button("Flex").SetFlexBasis(100f).SetFlexGrow(2f), UI.Button("Flex").SetFlexBasis(50f).SetFlexGrow(1f), UI.Button("Flex").SetFlexBasis(50f).SetFlexGrow(1f)).SetFlexWrap(true)),
                 ("UI.Button(\"Color\").SetColor(Color.red);", UI.Button("Color").SetColor(Color.red)),
                 ("UI.Button(\"BackgroundColor\").SetBackgroundColor(Color.blue);",
                     UI.Button("BackgroundColor").SetBackgroundColor(Color.blue))

--- a/Packages/ga.fuquna.rosettaui.uitoolkit/Runtime/Builder/UIToolkitBuilder.cs
+++ b/Packages/ga.fuquna.rosettaui.uitoolkit/Runtime/Builder/UIToolkitBuilder.cs
@@ -184,6 +184,8 @@ namespace RosettaUI.UIToolkit.Builder
             {
                 veStyle.flexGrow = ToStyleFloat(style.FlexGrow);
                 veStyle.flexShrink = ToStyleFloat(style.FlexShrink);
+                veStyle.flexBasis = ToStyleLength(style.FlexBasis);
+                veStyle.flexWrap = style.FlexWrap == true ? Wrap.Wrap : Wrap.NoWrap;
             }
             
             return;

--- a/Packages/ga.fuquna.rosettaui/Runtime/Elements/Utilities/ElementExtensionsMethodChain.cs
+++ b/Packages/ga.fuquna.rosettaui/Runtime/Elements/Utilities/ElementExtensionsMethodChain.cs
@@ -89,7 +89,20 @@ namespace RosettaUI
             element.Style.FlexShrink = flexShrink;
             return element;
         }
-        
+
+        public static T SetFlexBasis<T>(this T element, float? flexBasis)
+            where T : Element
+        {
+            element.Style.FlexBasis = flexBasis;
+            return element;
+        }
+
+        public static T SetFlexWrap<T>(this T element, bool? flexWrap)
+            where T : Element
+        {
+            element.Style.FlexWrap = flexWrap;
+            return element;
+        }
         public static T RegisterValueChangeCallback<T>(this T element, Action onValueChanged)
             where T : Element
         {

--- a/Packages/ga.fuquna.rosettaui/Runtime/Reactive/Style.cs
+++ b/Packages/ga.fuquna.rosettaui/Runtime/Reactive/Style.cs
@@ -18,6 +18,8 @@ namespace RosettaUI
         private Color? _backgroundColor;
         private float? _flexGrow;
         private float? _flexShrink;
+        private float? _flexBasis;
+        private bool? _flexWrap;
 
         public float? Width
         {
@@ -77,7 +79,18 @@ namespace RosettaUI
             get => _flexShrink;
             set => SetValue(ref _flexShrink, value);
         }
-        
+
+        public float? FlexBasis
+        {
+            get => _flexBasis;
+            set => SetValue(ref _flexBasis, value);
+        }
+
+        public bool? FlexWrap
+        {
+            get => _flexWrap;
+            set => SetValue(ref _flexWrap, value);
+        }
         #endregion
 
         private void SetValue<T>(ref T current, T newValue)

--- a/Packages/ga.fuquna.rosettaui/Runtime/UI/UICustom_ElementOverrideAttribute.cs
+++ b/Packages/ga.fuquna.rosettaui/Runtime/UI/UICustom_ElementOverrideAttribute.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace RosettaUI
+{
+    /// <summary>
+    /// 特定のAttributeで標準のフィールドのUIを改変できる
+    /// </summary>
+    public static partial class UICustom
+    {
+        private class OverrideFunc
+        {
+            public readonly bool isModify;
+            public readonly Func<PropertyAttribute, Element, LabelElement, IBinder, Element> func;
+            public readonly bool includeParentTypes;
+
+            public OverrideFunc(bool isModify, Func<PropertyAttribute, Element, LabelElement, IBinder, Element> func, bool includeParentTypes = false)
+            {
+                this.isModify = isModify;
+                this.func = func;
+                this.includeParentTypes = includeParentTypes;
+            }
+        }
+
+        private static readonly Dictionary<(Type, Type), OverrideFunc> OverrideByAttributeFuncTable = new();
+
+
+        #region ElementOverrideAttribute
+        // exclude parent type
+        public static void RegisterElementOverrideAttribute<TAttribute, TValue>(Func<TAttribute, LabelElement, Func<TValue>, Action<TValue>, Element> overrideFunc)
+            where TAttribute : PropertyAttribute
+        {
+            RegisterElementOverrideAttribute(typeof(TAttribute), typeof(TValue), new OverrideFunc(false, (attribute, originalElement, label, binder) =>
+                {
+                    if (binder is not IBinder<TValue> typedBinder) return originalElement;
+                    return overrideFunc((TAttribute)attribute, label, typedBinder.Get, typedBinder.Set);
+                }
+            ));
+        }
+
+        // exclude parent type
+        public static void RegisterElementOverrideAttribute<TAttribute, TValue>(Func<TAttribute, LabelElement, IBinder<TValue>, Element> overrideFunc)
+            where TAttribute : PropertyAttribute
+        {
+            RegisterElementOverrideAttribute(typeof(TAttribute), typeof(TValue), new OverrideFunc(false, (attribute, originalElement, label, binder) =>
+                {
+                    if (binder is not IBinder<TValue> typedBinder) return originalElement;
+                    return overrideFunc((TAttribute)attribute, label, typedBinder);
+                }
+            ));
+        }
+
+        // include parent type
+        public static void RegisterElementOverrideAttribute<TAttribute>(Type type, Func<TAttribute, LabelElement, IBinder, Element> overrideFunc)
+            where TAttribute : PropertyAttribute
+        {
+            RegisterElementOverrideAttribute(typeof(TAttribute), type, new OverrideFunc(false, (attribute, _, label, binder)
+                    => overrideFunc((TAttribute)attribute, label, binder),
+                true
+            ));
+        }
+
+        #region Scope
+        public readonly ref struct ElementOverrideAttributeScope
+        {
+            // exclude parent type
+            public static ElementOverrideAttributeScope Create<TAttribute, TValue>(Func<TAttribute, LabelElement, Func<TValue>, Action<TValue>, Element> overrideFunc)
+                where TAttribute : PropertyAttribute
+            {
+                var ret = new ElementOverrideAttributeScope(typeof(TAttribute), typeof(TValue));
+                RegisterElementOverrideAttribute(overrideFunc);
+                return ret;
+            }
+
+            // exclude parent type
+            public static ElementOverrideAttributeScope Create<TAttribute, TValue>(Func<TAttribute, LabelElement, IBinder<TValue>, Element> overrideFunc)
+                where TAttribute : PropertyAttribute
+            {
+                var ret = new ElementOverrideAttributeScope(typeof(TAttribute), typeof(TValue));
+                RegisterElementOverrideAttribute(overrideFunc);
+                return ret;
+            }
+
+            // include parent type
+            public static ElementOverrideAttributeScope Create<TAttribute>(Type type, Func<TAttribute, LabelElement, IBinder, Element> overrideFunc)
+                where TAttribute : PropertyAttribute
+            {
+                var ret = new ElementOverrideAttributeScope(type);
+                RegisterElementOverrideAttribute(type, overrideFunc);
+                return ret;
+            }
+
+            private readonly Type _attributeType;
+            private readonly Type _valueType;
+            private readonly OverrideFunc _attributeOverriderCache;
+
+            private ElementOverrideAttributeScope(Type attributeType, Type valueType = null)
+            {
+                _attributeType = attributeType;
+                _valueType = valueType;
+                _attributeOverriderCache = GetElementOverrideAttributeData(attributeType, valueType);
+            }
+
+            public void Dispose()
+            {
+                RegisterElementOverrideAttribute(_attributeType,  _valueType, _attributeOverriderCache);
+            }
+        }
+        #endregion
+
+        #endregion
+
+        #region ElementModifyAttribute
+        public static void RegisterElementModifyAttribute<TAttribute>(Func<TAttribute, Element, Element> overrideFunc)
+            where TAttribute : PropertyAttribute
+        {
+            RegisterElementOverrideAttribute(typeof(TAttribute), null, new OverrideFunc(true, (attribute, originalElement, _, _) =>
+                {
+                    return overrideFunc((TAttribute)attribute, originalElement);
+                },
+                true
+            ));
+        }
+
+        #region Scope
+        public readonly ref struct ElementModifyAttributeScope
+        {
+            public static ElementModifyAttributeScope Create<T>(Func<T, Element, Element> modifierFunc)
+                where T : PropertyAttribute
+            {
+                var ret = new ElementModifyAttributeScope(typeof(T));
+                RegisterElementModifyAttribute(modifierFunc);
+                return ret;
+            }
+
+            private readonly Type _type;
+            private readonly OverrideFunc _overrideFuncCache;
+
+            private ElementModifyAttributeScope(Type type)
+            {
+                _type = type;
+                _overrideFuncCache = GetElementOverrideAttributeData(type, null);
+            }
+
+            public void Dispose()
+            {
+                RegisterElementOverrideAttribute(_type, null, _overrideFuncCache);
+            }
+        }
+        #endregion
+        #endregion
+
+        private static void RegisterElementOverrideAttribute(Type attributeType, Type valueType, OverrideFunc overrideFunc)
+        {
+            OverrideByAttributeFuncTable[(attributeType, valueType)] = overrideFunc;
+        }
+
+        public static bool UnregisterElementOverrideAttribute(Type attributeType, Type valueType)
+        {
+            return OverrideByAttributeFuncTable.Remove((attributeType, valueType));
+        }
+
+        #region DataGetter
+        public static Func<PropertyAttribute, Element, LabelElement, IBinder, Element> GetElementOverrideAttribute(Type attributeType, Type valueType)
+        {
+            var overrideFunc = GetElementOverrideAttributeData(attributeType, valueType);
+            if (overrideFunc == null || overrideFunc.isModify) return null;
+            return overrideFunc.func;
+        }
+
+        public static Func<PropertyAttribute, Element, LabelElement, IBinder, Element> GetElementModifyAttribute(Type attributeType, Type valueType)
+        {
+            var overrideFunc = GetElementOverrideAttributeData(attributeType, valueType);
+            if (overrideFunc == null || !overrideFunc.isModify) return null;
+            return overrideFunc.func;
+        }
+
+        private static OverrideFunc GetElementOverrideAttributeData(Type attributeType, Type valueType, bool isTarget = true)
+        {
+            while (true)
+            {
+                if (OverrideByAttributeFuncTable.TryGetValue((attributeType, valueType), out var overrideFunc) && (isTarget || (overrideFunc?.includeParentTypes ?? false)))
+                {
+                    return overrideFunc;
+                }
+
+                if (valueType == null) return null;
+
+                valueType = valueType.BaseType;
+                isTarget = false;
+            }
+        }
+        #endregion
+    }
+}

--- a/Packages/ga.fuquna.rosettaui/Runtime/UI/UICustom_ElementOverrideAttribute.cs
+++ b/Packages/ga.fuquna.rosettaui/Runtime/UI/UICustom_ElementOverrideAttribute.cs
@@ -112,12 +112,12 @@ namespace RosettaUI
         #endregion
 
         #region ElementModifyAttribute
-        public static void RegisterElementModifyAttribute<TAttribute>(Func<TAttribute, Element, Element> overrideFunc)
+        public static void RegisterElementModifyAttribute<TAttribute>(Func<TAttribute, Element, Element> modifyFunc)
             where TAttribute : PropertyAttribute
         {
             RegisterElementOverrideAttribute(typeof(TAttribute), null, new OverrideFunc(true, (attribute, originalElement, _, _) =>
                 {
-                    return overrideFunc((TAttribute)attribute, originalElement);
+                    return modifyFunc((TAttribute)attribute, originalElement);
                 },
                 true
             ));
@@ -126,11 +126,11 @@ namespace RosettaUI
         #region Scope
         public readonly ref struct ElementModifyAttributeScope
         {
-            public static ElementModifyAttributeScope Create<T>(Func<T, Element, Element> modifierFunc)
+            public static ElementModifyAttributeScope Create<T>(Func<T, Element, Element> modifyFunc)
                 where T : PropertyAttribute
             {
                 var ret = new ElementModifyAttributeScope(typeof(T));
-                RegisterElementModifyAttribute(modifierFunc);
+                RegisterElementModifyAttribute(modifyFunc);
                 return ret;
             }
 

--- a/Packages/ga.fuquna.rosettaui/Runtime/UI/UICustom_ElementOverrideAttribute.cs.meta
+++ b/Packages/ga.fuquna.rosettaui/Runtime/UI/UICustom_ElementOverrideAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b7fd0b8ad6274da397cf27e4a7d748e7
+timeCreated: 1743685479


### PR DESCRIPTION
# Changes

## Added custom attribute registration function to configure custom GUI ( #24 )
- RegisterElementOverrideAttribute() - registers a UI generation function for a given combination of attribute type and value type (input is IBinder or value getter / setter)
- RegisterElementModifyAttribute() - registers a UI editing function for the specified attribute type (input is Element)

Also, I added the related Scopes.

Class & Attributes defines: 
```c#
public class MySuffixAttribute : PropertyAttribute
{
    public string suffix;
}

public class MyDropDownAttribute : PropertyAttribute { }

[Serializable]
public class MyAttributeClass
{
    public float value;
    [MySuffix(suffix = "suffix")] public float suffixValue;
    public string stringValue;
    [MyDropDown] public string myDropDownStringValue = "A";
}
```

CreateElement:
```c#
Element CreateElement(LabelElement label)
{
     using var modifyScope = UICustom.ElementModifyAttributeScope.Create<MySuffixAttribute>((attribute, element) =>
     {
          return UI.Row(element, UI.Label(attribute.suffix), UI.Space().SetWidth(4f));
     });

     using var overrideScope = UICustom.ElementOverrideAttributeScope.Create<MyDropDownAttribute, string>((attribute, label, readValue, writeValue) =>
     {
          return UI.Dropdown(label, readValue, writeValue, new[] { "A", "B", "C" });
     });

     return UI.Field(() => myAttributeClass);
}
```

### Scripting Interfaces
```c#
void RegisterElementOverrideAttribute<TAttribute, TValue>(Func<TAttribute, LabelElement, Func<TValue>, Action<TValue>, Element> overrideFunc);
void RegisterElementOverrideAttribute<TAttribute, TValue>(Func<TAttribute, LabelElement, IBinder<TValue>, Element> overrideFunc);
void RegisterElementOverrideAttribute<TAttribute>(Type type, Func<TAttribute, LabelElement, IBinder, Element> overrideFunc);

ElementOverrideAttributeScope ElementOverrideAttributeScope.Create<TAttribute, TValue>(Func<TAttribute, LabelElement, Func<TValue>, Action<TValue>, Element> overrideFunc);
ElementOverrideAttributeScope ElementOverrideAttributeScope.Create<TAttribute, TValue>(Func<TAttribute, LabelElement, IBinder<TValue>, Element> overrideFunc);
ElementOverrideAttributeScope ElementOverrideAttributeScope.Create<TAttribute>(Type type, Func<TAttribute, LabelElement, IBinder, Element> overrideFunc);

void RegisterElementModifyAttribute<TAttribute>(Func<TAttribute, Element, Element> modifyFunc);

ElementModifyAttributeScope ElementModifyAttributeScope.Create<T>(Func<T, Element, Element> modifierFunc);

```

### Note
This works only in fields of class. (UI.Field(() => someClassIncludingAtrributedField)), Not working in direct registration of field (UI.Field(() => fieldWithAttribute)

## Add styles of FlexBasis and FlexWrap, related extension methods
- This feature is needed to make same width buttons with diferrent texts.
```c#
UI.Row(
    UI.Button("Flex").SetFlexBasis(100f).SetFlexGrow(2f),
    UI.Button("FlexFlex").SetFlexBasis(50f).SetFlexGrow(1f),
    UI.Button("Flex").SetFlexBasis(50f).SetFlexGrow(1f)
).SetFlexWrap(true);"
```
![image](https://github.com/user-attachments/assets/b504656c-2500-4bde-9911-999933403331)
